### PR TITLE
Improve phase chart auto-refresh

### DIFF
--- a/src/components/PhaseChart.js
+++ b/src/components/PhaseChart.js
@@ -1,0 +1,88 @@
+import React, { useEffect, useState } from 'react';
+import { Paper, Typography } from '@mui/material';
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer
+} from 'recharts';
+
+const colors = [
+  '#00ff64',
+  '#00b4ff',
+  '#ff4081',
+  '#ff9800',
+  '#aa00ff',
+  '#ffea00',
+  '#00e5ff',
+  '#7c4dff',
+  '#c6ff00',
+  '#ff1744'
+];
+
+const REFRESH_MS = 2000; // poll interval in milliseconds
+
+const PhaseChart = () => {
+  const [data, setData] = useState([]);
+  const [lines, setLines] = useState([]);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const res = await fetch('/api/phaseData');
+        if (!res.ok) throw new Error('Failed to load phase data');
+        const devices = await res.json();
+        const lineDefs = devices.map((dev, idx) => ({
+          key: `D${dev.id}`,
+          color: colors[idx % colors.length]
+        }));
+
+        const maxChannels = Math.max(
+          ...devices.map(d => d.channels.length)
+        );
+        const rows = [];
+        for (let i = 0; i < maxChannels; i++) {
+          const row = { channel: devices[0].channels[i]?.name || `Ch${i}` };
+          devices.forEach(dev => {
+            if (dev.channels[i]) {
+              row[`D${dev.id}`] = dev.channels[i].meanPhase;
+            }
+          });
+          rows.push(row);
+        }
+
+        setLines(lineDefs);
+        setData(rows);
+      } catch (err) {
+        console.error(err);
+      }
+    }
+    load();
+    const timer = setInterval(load, REFRESH_MS);
+    return () => clearInterval(timer);
+  }, []);
+
+  return (
+    <Paper sx={{ p: 2, backgroundColor: '#10102a' }}>
+      <Typography variant="h6" sx={{ color: '#00b4ff', mb: 1 }}>
+        Channel Phases
+      </Typography>
+      <ResponsiveContainer width="100%" height={400}>
+        <LineChart data={data} margin={{ top: 10, right: 20, left: 10, bottom: 0 }}>
+          <CartesianGrid strokeDasharray="3 3" stroke="#555" />
+          <XAxis dataKey="channel" stroke="#ccc" interval={0} angle={-45} textAnchor="end" height={80} />
+          <YAxis domain={[-Math.PI, Math.PI]} stroke="#ccc" tickFormatter={v => v.toFixed(2)} />
+          <Tooltip formatter={(v) => v.toFixed(2)} />
+          {lines.map(l => (
+            <Line key={l.key} type="monotone" dataKey={l.key} stroke={l.color} dot={false} />
+          ))}
+        </LineChart>
+      </ResponsiveContainer>
+    </Paper>
+  );
+};
+
+export default PhaseChart;

--- a/src/pages/api/phaseData.js
+++ b/src/pages/api/phaseData.js
@@ -5,20 +5,37 @@ import path from 'path';
 export default function handler(req, res) {
   try {
     const filePath = path.join(process.cwd(), 'public', 'data', 'phase_data.txt');
-    const rawData = fs.readFileSync(filePath, 'utf8');
-    
-    const phaseData = rawData
-      .split('\n')
-      .filter(line => line.trim() && !line.startsWith('#'))
-      .map(line => {
-        const [deviceId, ...phases] = line.split(',');
-        return {
-          deviceId: parseInt(deviceId),
-          phases: phases.map(Number)
-        };
-      });
+    const raw = fs.readFileSync(filePath, 'utf8');
 
-    res.status(200).json(phaseData);
+    const devices = [];
+    let current = null;
+    raw.split(/\r?\n/).forEach(line => {
+      if (!line.trim() || line.startsWith('#')) return;
+      const parts = line.split(',');
+      if (parts[0] === 'DEVICE') {
+        if (current) devices.push(current);
+        current = {
+          id: parseInt(parts[1]),
+          serial: parts[2].trim(),
+          model: parts[3].trim(),
+          captureCount: parseInt(parts[4]) || 0,
+          channels: []
+        };
+      } else if (parts[0] === 'PHASE' && current) {
+        const meanPhase = parseFloat(parts[3]);
+        current.channels.push({
+          channel: parseInt(parts[1]),
+          name: parts[2].trim(),
+          meanPhase,
+          meanPhaseDeg: meanPhase * 180 / Math.PI,
+          variance: parseFloat(parts[4])
+        });
+      }
+    });
+    if (current) devices.push(current);
+
+    res.setHeader('Cache-Control', 'no-store');
+    res.status(200).json(devices);
   } catch (error) {
     console.error('Error loading phase data:', error);
     res.status(500).json({ error: 'Failed to load phase data' });

--- a/src/pages/phase-plot.js
+++ b/src/pages/phase-plot.js
@@ -1,0 +1,23 @@
+'use client';
+import React from 'react';
+import Head from 'next/head';
+import { ThemeProvider, CssBaseline, Container } from '@mui/material';
+import { darkTheme } from '../styles/styledComponents';
+import PhaseChart from '../components/PhaseChart';
+
+const PhasePlotPage = () => (
+  <>
+    <Head>
+      <title>Real-Time Phase Analysis</title>
+      <meta name="description" content="Visualisation of channel phase updates" />
+    </Head>
+    <ThemeProvider theme={darkTheme}>
+      <CssBaseline />
+      <Container sx={{ py: 4 }}>
+        <PhaseChart />
+      </Container>
+    </ThemeProvider>
+  </>
+);
+
+export default PhasePlotPage;


### PR DESCRIPTION
## Summary
- poll `/api/phaseData` every 2 seconds
- disable caching in `phaseData` API
- update PhasePlotPage title

## Testing
- `npm install`
- `npm run lint` *(fails: interactive prompt)*

------
https://chatgpt.com/codex/tasks/task_e_687f262bb5ac832d86fda5d11c7c3bb7